### PR TITLE
update: Separate the RabbitMQ Implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/carlosm27/go-rabbitmq-demo
 
-go 1.21.0
+go 1.21
 
-require github.com/rabbitmq/amqp091-go v1.9.0 // indirect
+require github.com/rabbitmq/amqp091-go v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -2,20 +2,49 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	"time"
 
-	amqp "github.com/rabbitmq/amqp091-go"
+	msgbroker "github.com/carlosm27/go-rabbitmq-demo/pkg/msg-broker"
+	"github.com/carlosm27/go-rabbitmq-demo/pkg/msg-broker/rabbitmq"
 )
+
+type MsgBroker interface {
+	PublishMessage(ctx context.Context, queueSettings msgbroker.QueueSettings, msgBody []byte) error
+}
+
+var msgBroker MsgBroker
 
 func main() {
 
 	mux := http.NewServeMux()
 	port := ":8000"
 
-	mux.Handle("/", http.HandlerFunc(homeHandler))
+	// Create the rabbitMQ message broker implementation
+	msgBroker, onClose := rabbitmq.MustGetNewRabbitMqBroker("amqp://guest:guest@localhost:5672/")
+	defer onClose()
+
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		w.Write([]byte("Hello this is a home page"))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Declare the queue settings
+		queueSettings := msgbroker.QueueSettings{Name: "hello"}
+
+		// publish the rabbitMQ message
+		body := "Hello World!"
+		err := msgBroker.PublishMessage(ctx, queueSettings, []byte(body))
+		if err != nil {
+			panic(fmt.Errorf("failed to publish a message: %v", err))
+		}
+		log.Printf(" [x] Sent %s\n", body)
+	}))
 
 	slog.Info("Listening on ", "port", port)
 
@@ -23,54 +52,5 @@ func main() {
 	if err != nil {
 		slog.Warn("Problem starting the server", "error", err)
 	}
-
-}
-
-func homeHandler(w http.ResponseWriter, r *http.Request) {
-
-	w.Write([]byte("Hello this is a home page"))
-	rabbitmqConnection()
-
-}
-
-func failOnError(err error, msg string) {
-	if err != nil {
-		log.Panicf("%s: %s", msg, err)
-	}
-}
-
-func rabbitmqConnection() {
-	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
-	failOnError(err, "Failed to connect to RabbitMQ")
-	defer conn.Close()
-	ch, err := conn.Channel()
-	failOnError(err, "Failed to open a channel")
-	defer ch.Close()
-
-	q, err := ch.QueueDeclare(
-		"hello", // name
-		false,   // durable
-		false,   // delete when unused
-		false,   // exclusive
-		false,   // no-wait
-		nil,     // arguments
-	)
-	failOnError(err, "Failed to declare a queue")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	body := "Hello World!"
-	err = ch.PublishWithContext(ctx,
-		"",     // exchange
-		q.Name, // routing key
-		false,  // mandatory
-		false,  // immediate
-		amqp.Publishing{
-			ContentType: "text/plain",
-			Body:        []byte(body),
-		})
-	failOnError(err, "Failed to publish a message")
-	log.Printf(" [x] Sent %s\n", body)
 
 }

--- a/pkg/msg-broker/msgBroker.go
+++ b/pkg/msg-broker/msgBroker.go
@@ -1,0 +1,10 @@
+package msgbroker
+
+type QueueSettings struct {
+	Name       string
+	Durable    bool
+	AutoDelete bool
+	Exclusive  bool
+	NoWait     bool
+	Args       map[string]interface{}
+}

--- a/pkg/msg-broker/rabbitmq/rabbitmq.go
+++ b/pkg/msg-broker/rabbitmq/rabbitmq.go
@@ -1,0 +1,63 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+
+	msgbroker "github.com/carlosm27/go-rabbitmq-demo/pkg/msg-broker"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type RabbitMqBroker struct {
+	ch *amqp.Channel
+}
+
+func MustGetNewRabbitMqBroker(url string) (*RabbitMqBroker, func()) {
+	// --- (1) ----
+	// Try to create the connection
+	conn, err := amqp.Dial(url)
+	if err != nil {
+		panic(fmt.Errorf("failed to connect to RabbitMQ: %v", err))
+	}
+	// --- (2) ----
+	// Try to create the channel
+	ch, err := conn.Channel()
+	if err != nil {
+		panic(fmt.Errorf("failed to create RabbitMQ channel: %v", err))
+	}
+	return &RabbitMqBroker{
+			ch: ch,
+		}, func() {
+			ch.Close()
+			conn.Close()
+		}
+}
+
+func (br *RabbitMqBroker) PublishMessage(ctx context.Context, queueSettings msgbroker.QueueSettings, msgBody []byte) error {
+	// --- (1) ----
+	// First we need to cleare the message queue where the message will be published
+	q, err := br.ch.QueueDeclare(
+		queueSettings.Name,
+		queueSettings.Durable,
+		queueSettings.AutoDelete,
+		queueSettings.Exclusive,
+		queueSettings.NoWait,
+		queueSettings.Args,
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- (2) ----
+	// If the queue is successfully created, we can procede to publish the message
+	err = br.ch.PublishWithContext(ctx,
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        msgBody,
+		})
+	return err
+}


### PR DESCRIPTION
Currently the entire rabbitMQ implementation is inside the main.go 

I have implemented a specific pkg folder where the rabbitMQ implementation is stored. I have also made a little more expandable just in case this solution can be reused to compare different messaging brokers.

TODO: Maybe we should add some tests to this as well.

Let me know if you like the implementation.